### PR TITLE
chore: upgrade to CyberChef v11.0.0, refresh base images and actions

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -33,14 +33,13 @@ jobs:
 
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
 
@@ -48,14 +47,14 @@ jobs:
       # https://github.com/docker/login-action
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -72,9 +71,10 @@ jobs:
         if: github.event_name != 'push' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
         
       - name: Use tag name as version if run on a tag push
+        id: version_tag
         run: |
           TAG_NAME=$(basename ${GITHUB_REF##*/})
-          echo ::set-output name=tag_name::${TAG_NAME}
+          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
         if: github.event_name == 'push' || startsWith(github.ref, 'refs/tags/')
 
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.IMAGES }}
@@ -104,16 +104,13 @@ jobs:
       # Now we build multiarch packages with Dockerfile.build
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           platforms: |
             linux/amd64
             linux/arm64
-            linux/i386
-            linux/armhf
-            linux/armel
           build-args: |
             GIT_TAG=${{ steps.version.outputs.tag_name }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -142,7 +139,7 @@ jobs:
         id: latest_tag
 
       - name: Check if tag already exists
-        uses: mukunku/tag-exists-action@v1.0.0
+        uses: mukunku/tag-exists-action@v1.7.0
         id: checkTag
         with:
           tag: ${{ steps.version.outputs.tag_name }}
@@ -174,7 +171,7 @@ jobs:
 
       - if: ${{ github.event_name != 'pull_request' }}
         name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME  }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 # syntax=docker/dockerfile:1
 
-# Stage 1: Builder stage using Node.js 18 image
-FROM --platform=$BUILDPLATFORM docker.io/node:18 AS builder
+# Stage 1: Builder stage using Node.js 24 Alpine image (CyberChef v11 requires Node >=24 <25)
+FROM --platform=$BUILDPLATFORM docker.io/node:24-alpine AS builder
 ARG GIT_TAG=
+
+# git is required to clone the upstream CyberChef repository
+RUN apk add --no-cache git
 
 # Clone the CyberChef repository into /srv directory
 RUN git clone https://github.com/gchq/CyberChef /srv
@@ -11,8 +14,8 @@ WORKDIR /srv
 # Checkout the specified git tag if provided
 RUN if [ -n "${GIT_TAG}" ]; then git checkout ${GIT_TAG}; fi
 
-# Increase Node.js memory limit to 2GB for build process
-ENV NODE_OPTIONS="--max-old-space-size=2048"
+# Increase Node.js memory limit to 4GB for build process
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Install npm dependencies
 RUN npm install
@@ -20,7 +23,7 @@ RUN npm install
 # Run the production build
 RUN npm run build
 
-# Stage 4: Final application stage using unprivileged nginx on Alpine
+# Stage 2: Final application stage using unprivileged nginx on Alpine
 FROM docker.io/nginxinc/nginx-unprivileged:alpine AS app
 
 # Change nginx listen port from 8080 to 8000 to maintain compatibility with old http-server


### PR DESCRIPTION
## Summary

- Bump builder base image from `node:18` (Debian) to `node:24-alpine` — CyberChef v11.0.0 requires Node `>=24 <25`.
- Refresh GitHub Actions to current major versions (`checkout`, `setup-buildx`, `login-action`, `metadata-action`, `build-push-action`, `cosign-installer`, `tag-exists-action`, `dockerhub-description`).
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT`.
- Drop `linux/i386`, `linux/armhf`, `linux/armel` from build platforms — `node:24-alpine` only ships `amd64`, `arm64` and `s390x`, so those targets would fail.
- Bump `NODE_OPTIONS` memory ceiling from 2GB to 4GB for the heavier v11 build.

## Test plan

- [ ] Workflow run triggered on `main` produces a passing build for `linux/amd64` and `linux/arm64`.
- [ ] Image `ghcr.io/obeone/cyberchef:v11.0.0` is published and signed by cosign.
- [ ] Container starts and serves CyberChef v11 UI on port 8000.
- [ ] Tag `v11.0.0` is auto-created on this repo by `rickstaa/action-create-tag`.